### PR TITLE
Fix issue when multiple names under different domains are provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,27 @@ either use case in order to facilitate a future migration to Route 53 if desired
 
 ```hcl
 locals {
-   alt_names_zones = "${map(
-     "foo.example.com", "XXXXXXXXXXXXXX",
-     "moo.example.com", "XXXXXXXXXXXXXX",
-     "www.example.net", "YYYYYYYYYYYYYY",
-     )}"
+  fqdn_to_r53zone_map = "${map(
+    "example.com", "XXXXXXXXXXXXXX",
+    "foo.example.com", "XXXXXXXXXXXXXX",
+    "moo.example.com", "XXXXXXXXXXXXXX",
+    "www.example.net", "YYYYYYYYYYYYYY",
+    )}"
 }
 
 module "acm" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.2"
 
-   domain                = "example.com"
-   environment           = "Production"
-   domain_r53_zone_id    = "XXXXXXXXXXXXXX"
-   alt_names_zones       = "${local.alt_names_zones}"
-   alt_names_zones_count = 3
-   zone_ids_provided     = true
+  fqdn_list                 = ["example.com"]
+  environment               = "Production"
+  fqdn_to_r53zone_map       = "${local.fqdn_to_r53zone_map}"
+  fqdn_to_r53zone_map_count = 3
 
-   custom_tags = {
-     hello = "world"
-   }
+  custom_tags = {
+    hello = "world"
+  }
 }
+
 ```
 
 Full working references are available at [examples](examples)
@@ -41,15 +41,13 @@ Full working references are available at [examples](examples)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| alt\_names\_zones | A map of alternate names and route53 zone ids. The key for each pair is the alternate name in which a certficate must be generated. The value in the pair must be the Route53 zone id in which DNS verification will executed for the given alternate name. IF DNS/R53 validation will not be executed, the value can be left as empty quotes. | map | `<map>` | no |
-| alt\_names\_zones\_count | Provide the count of key/value pairs provided in variable alt_names_zones | string | `"0"` | no |
 | custom\_tags | Optional tags to be applied on top of the base tags on all resources | map | `<map>` | no |
-| domain | A domain name for which the certificate should be issued | string | n/a | yes |
-| domain\_r53\_zone\_id | A domain name for which the certificate should be issued | string | `""` | no |
 | environment | Application environment for which this network is being created. e.g. Development/Production | string | `"Development"` | no |
-| validation\_creation\_timeout | aws_acm_certificate_validation resource creation timeout. | string | `"30m"` | no |
+| fqdn\_list | A list FQDNs for which the certificate should be issued. | list | `<list>` | no |
+| fqdn\_to\_r53zone\_map | A map of alternate Route 53 zone ids and corresponding FQDNs to validate. The key for each pair is the FQDN in which a certficate must be generated. This map will typically contain all of the FQDNS provided in fqdn_list. | map | `<map>` | no |
+| fqdn\_to\_r53zone\_map\_count | Provide the count of key/value pairs provided in variable fqdn_to_r53zone_map | string | `"0"` | no |
+| validation\_creation\_timeout | aws_acm_certificate_validation resource creation timeout. | string | `"45m"` | no |
 | validation\_method | Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform. | string | `"DNS"` | no |
-| zone\_ids\_provided | Route53 Zone IDs were provided. A R53 Zone ID must be specified for each domain/alternate name if route53 validation is desired. | string | `"false"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module "acm" {
   fqdn_list                 = ["example.com"]
   environment               = "Production"
   fqdn_to_r53zone_map       = "${local.fqdn_to_r53zone_map}"
-  fqdn_to_r53zone_map_count = 3
+  fqdn_to_r53zone_map_count = 4
 
   custom_tags = {
     hello = "world"

--- a/README.md
+++ b/README.md
@@ -11,12 +11,27 @@ either use case in order to facilitate a future migration to Route 53 if desired
 ## Basic Usage
 
 ```hcl
-module "acm" {
-    source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.1"
+locals {
+   alt_names_zones = "${map(
+     "foo.example.com", "XXXXXXXXXXXXXX",
+     "moo.example.com", "XXXXXXXXXXXXXX",
+     "www.example.net", "YYYYYYYYYYYYYY",
+     )}"
+}
 
-    domain = "example.com"
-    subject_alternative_names = ["foo.example.com", "bar.example.com"]
-    route53_zone_id = "XXXXXXXXXXXXXX"
+module "acm" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.2"
+
+   domain                = "example.com"
+   environment           = "Production"
+   domain_r53_zone_id    = "XXXXXXXXXXXXXX"
+   alt_names_zones       = "${local.alt_names_zones}"
+   alt_names_zones_count = 3
+   zone_ids_provided     = true
+
+   custom_tags = {
+     hello = "world"
+   }
 }
 ```
 
@@ -26,12 +41,15 @@ Full working references are available at [examples](examples)
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| alt\_names\_zones | A map of alternate names and route53 zone ids. The key for each pair is the alternate name in which a certficate must be generated. The value in the pair must be the Route53 zone id in which DNS verification will executed for the given alternate name. IF DNS/R53 validation will not be executed, the value can be left as empty quotes. | map | `<map>` | no |
+| alt\_names\_zones\_count | Provide the count of key/value pairs provided in variable alt_names_zones | string | `"0"` | no |
 | custom\_tags | Optional tags to be applied on top of the base tags on all resources | map | `<map>` | no |
 | domain | A domain name for which the certificate should be issued | string | n/a | yes |
+| domain\_r53\_zone\_id | A domain name for which the certificate should be issued | string | `""` | no |
 | environment | Application environment for which this network is being created. e.g. Development/Production | string | `"Development"` | no |
-| route53\_zone\_id | Zone ID of the Route 53 Hosted Zone that will be used to create records for DNS-based validation when the `validation_method` is set to `DNS`. If `validation_method` is not set to `DNS`, or if a `route53_zone_id` is not provided, then no automated validation will be attempted. | string | `""` | no |
-| subject\_alternative\_names | A list of domains that should be SANs in the issued certificate | list | `<list>` | no |
+| validation\_creation\_timeout | aws_acm_certificate_validation resource creation timeout. | string | `"30m"` | no |
 | validation\_method | Which method to use for validation. `DNS` or `EMAIL` are valid, `NONE` can be used for certificates that were imported into ACM and then into Terraform. | string | `"DNS"` | no |
+| zone\_ids\_provided | Route53 Zone IDs were provided. A R53 Zone ID must be specified for each domain/alternate name if route53 validation is desired. | string | `"false"` | no |
 
 ## Outputs
 

--- a/examples/complete-with-route53.tf
+++ b/examples/complete-with-route53.tf
@@ -1,5 +1,6 @@
 locals {
-  alt_names_zones = "${map(
+  fqdn_to_r53zone_map = "${map(
+    "example.com", "XXXXXXXXXXXXXX",
     "foo.example.com", "XXXXXXXXXXXXXX",
     "moo.example.com", "XXXXXXXXXXXXXX",
     "www.example.net", "YYYYYYYYYYYYYY",
@@ -9,12 +10,10 @@ locals {
 module "acm" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.2"
 
-  domain                = "example.com"
-  environment           = "Production"
-  domain_r53_zone_id    = "XXXXXXXXXXXXXX"
-  alt_names_zones       = "${local.alt_names_zones}"
-  alt_names_zones_count = 3
-  zone_ids_provided     = true
+  fqdn_list                 = ["example.com"]
+  environment               = "Production"
+  fqdn_to_r53zone_map       = "${local.fqdn_to_r53zone_map}"
+  fqdn_to_r53zone_map_count = 3
 
   custom_tags = {
     hello = "world"

--- a/examples/complete-with-route53.tf
+++ b/examples/complete-with-route53.tf
@@ -1,10 +1,20 @@
-module "acm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.1"
+locals {
+  alt_names_zones = "${map(
+    "foo.example.com", "XXXXXXXXXXXXXX",
+    "moo.example.com", "XXXXXXXXXXXXXX",
+    "www.example.net", "YYYYYYYYYYYYYY",
+    )}"
+}
 
-  domain                    = "example.com"
-  environment               = "Production"
-  route53_zone_id           = "XXXXXXXXXXXXXX"
-  subject_alternative_names = ["foo.example.com", "bar.example.com"]
+module "acm" {
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.2"
+
+  domain                = "example.com"
+  environment           = "Production"
+  domain_r53_zone_id    = "XXXXXXXXXXXXXX"
+  alt_names_zones       = "${local.alt_names_zones}"
+  alt_names_zones_count = 3
+  zone_ids_provided     = true
 
   custom_tags = {
     hello = "world"

--- a/examples/minimal-with-email.tf
+++ b/examples/minimal-with-email.tf
@@ -1,11 +1,9 @@
 module "acm" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.1"
 
-  domain                = "example.com"
-  environment           = "Test"
-  validation_method     = "Email"
-  zone_ids_provided     = false
-  alt_names_zones_count = 0
+  fqdn_list         = ["example.com"]
+  environment       = "Test"
+  validation_method = "Email"
 
   custom_tags = {
     hello = "world"

--- a/examples/minimal-with-email.tf
+++ b/examples/minimal-with-email.tf
@@ -1,8 +1,11 @@
 module "acm" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.1"
 
-  domain      = "example.com"
-  environment = "Test"
+  domain                = "example.com"
+  environment           = "Test"
+  validation_method     = "Email"
+  zone_ids_provided     = false
+  alt_names_zones_count = 0
 
   custom_tags = {
     hello = "world"

--- a/examples/minimal-with-external-dns.tf
+++ b/examples/minimal-with-external-dns.tf
@@ -1,7 +1,7 @@
 module "acm" {
   source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.2"
 
-  domain      = "example.com"
+  fqdn_list   = ["example.com"]
   environment = "Production"
 
   custom_tags = {

--- a/examples/minimal-with-external-dns.tf
+++ b/examples/minimal-with-external-dns.tf
@@ -1,5 +1,5 @@
 module "acm" {
-  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.1"
+  source = "git@github.com:rackspace-infrastructure-automation/aws-terraform-acm//?ref=v0.0.2"
 
   domain      = "example.com"
   environment = "Production"

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@
  *   fqdn_list                 = ["example.com"]
  *   environment               = "Production"
  *   fqdn_to_r53zone_map       = "${local.fqdn_to_r53zone_map}"
- *   fqdn_to_r53zone_map_count = 3
+ *   fqdn_to_r53zone_map_count = 4
  * 
  *   custom_tags = {
  *     hello = "world"

--- a/tests/minimal-with-external-dns.tf/main.tf
+++ b/tests/minimal-with-external-dns.tf/main.tf
@@ -12,7 +12,7 @@ resource "random_string" "rstring" {
 
 module "acm" {
   source      = "../../module"
-  domain      = "${random_string.rstring.result}.mupo181ve1jco37.net"
+  fqdn_list   = ["${random_string.rstring.result}.mupo181ve1jco37.net"]
   environment = "Production"
 
   custom_tags = {

--- a/tests/minimal-with-external-dns.tf/main.tf
+++ b/tests/minimal-with-external-dns.tf/main.tf
@@ -11,8 +11,7 @@ resource "random_string" "rstring" {
 }
 
 module "acm" {
-  source = "../../module"
-
+  source      = "../../module"
   domain      = "${random_string.rstring.result}.mupo181ve1jco37.net"
   environment = "Production"
 

--- a/variables.tf
+++ b/variables.tf
@@ -9,27 +9,45 @@ variable "domain" {
   type        = "string"
 }
 
+variable "domain_r53_zone_id" {
+  description = "A domain name for which the certificate should be issued"
+  type        = "string"
+  default     = ""
+}
+
 variable "environment" {
   description = "Application environment for which this network is being created. e.g. Development/Production"
   type        = "string"
   default     = "Development"
 }
 
-variable "route53_zone_id" {
+variable "alt_names_zones" {
   description = <<HEREDOC
-Zone ID of the Route 53 Hosted Zone that will be used to create records for DNS-based validation when the
-`validation_method` is set to `DNS`. If `validation_method` is not set to `DNS`, or if a `route53_zone_id` is not
-provided, then no automated validation will be attempted.
+A map of alternate names and route53 zone ids. The key for each pair is the alternate name in which a certficate must be generated.
+The value in the pair must be the Route53 zone id in which DNS verification will executed for the given alternate name.
+IF DNS/R53 validation will not be executed, the value can be left as empty quotes.
 HEREDOC
 
-  type    = "string"
-  default = ""
+  type    = "map"
+  default = {}
 }
 
-variable "subject_alternative_names" {
-  description = "A list of domains that should be SANs in the issued certificate"
-  type        = "list"
-  default     = []
+variable "alt_names_zones_count" {
+  description = "Provide the count of key/value pairs provided in variable alt_names_zones"
+  type        = "string"
+  default     = 0
+}
+
+variable "zone_ids_provided" {
+  description = "Route53 Zone IDs were provided. A R53 Zone ID must be specified for each domain/alternate name if route53 validation is desired."
+  type        = "string"
+  default     = false
+}
+
+variable "validation_creation_timeout" {
+  description = "aws_acm_certificate_validation resource creation timeout."
+  type        = "string"
+  default     = "30m"
 }
 
 variable "validation_method" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,15 +4,10 @@ variable "custom_tags" {
   default     = {}
 }
 
-variable "domain" {
-  description = "A domain name for which the certificate should be issued"
-  type        = "string"
-}
-
-variable "domain_r53_zone_id" {
-  description = "A domain name for which the certificate should be issued"
-  type        = "string"
-  default     = ""
+variable "fqdn_list" {
+  description = "A list FQDNs for which the certificate should be issued."
+  type        = "list"
+  default     = []
 }
 
 variable "environment" {
@@ -21,33 +16,26 @@ variable "environment" {
   default     = "Development"
 }
 
-variable "alt_names_zones" {
+variable "fqdn_to_r53zone_map" {
   description = <<HEREDOC
-A map of alternate names and route53 zone ids. The key for each pair is the alternate name in which a certficate must be generated.
-The value in the pair must be the Route53 zone id in which DNS verification will executed for the given alternate name.
-IF DNS/R53 validation will not be executed, the value can be left as empty quotes.
+A map of alternate Route 53 zone ids and corresponding FQDNs to validate. The key for each pair is the FQDN in which a certficate must be generated.
+This map will typically contain all of the FQDNS provided in fqdn_list.
 HEREDOC
 
   type    = "map"
   default = {}
 }
 
-variable "alt_names_zones_count" {
-  description = "Provide the count of key/value pairs provided in variable alt_names_zones"
+variable "fqdn_to_r53zone_map_count" {
+  description = "Provide the count of key/value pairs provided in variable fqdn_to_r53zone_map"
   type        = "string"
   default     = 0
-}
-
-variable "zone_ids_provided" {
-  description = "Route53 Zone IDs were provided. A R53 Zone ID must be specified for each domain/alternate name if route53 validation is desired."
-  type        = "string"
-  default     = false
 }
 
 variable "validation_creation_timeout" {
   description = "aws_acm_certificate_validation resource creation timeout."
   type        = "string"
-  default     = "30m"
+  default     = "45m"
 }
 
 variable "validation_method" {


### PR DESCRIPTION
##### Corresponding Issue(s) or trello card(s):
https://jira.rax.io/browse/MPCSUPENG-226 and https://github.com/rackspace-infrastructure-automation/aws-terraform-internal/issues/222
##### Summary of change(s):

- Modify logic and variables to allow for subjective alternate names to be provided that may not necessarily belong to the domain provided to the module.
- This was completed by updating variables to a map for alternate names that provide name/zone_id pairing.
- Other variables were also updated accordingly.

##### Will the change trigger resource destruction or replacement? If yes, please provide justification:
It is possible in some scenarios. Logic around counts were modified.
##### Does this update/change involve issues with other external modules? If so, please describe the scenario.
No

##### If input variables or output variables have changed or has been added, have you updated the README?
Has been updated
##### Do examples need to be updated based on changes?
Has been updated
##### Note to the PR requester about Closing PR's
Please message the person that opened the issue when auto closing it on slack, as well as any other stake holders of deep interest. Only close the issue if you believe that the issue is fully resolved with this PR.

#### This PR may auto close the issue associated with it. If you feel the issue is not resolved please reopen the issue.